### PR TITLE
fix: name artifacts based on the artifact name

### DIFF
--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ matrix.os }}-${{ matrix.arch }}
+          name: ${{ inputs.artifact_name }}-${{ matrix.os }}-${{ matrix.arch }}
           path: artifacts/
           retention-days: 1
 
@@ -106,7 +106,7 @@ jobs:
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: build-artifacts-*
+          pattern: ${{ inputs.artifact_name }}-*
           path: artifacts/
       - name: Upload release artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Names artifacts based on the artifact name instead of hardcoding it. Hardcoding breaks when we have to build multiple binaries in 1 flow.