### PR TITLE
feat: use default cargo test instead of nextest

### DIFF
--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           key: ${{ inputs.rust-channel }}-test-${{ inputs.require-lockfile }}-${{ matrix.feature-set }}
 
-      - uses: taiki-e/install-action@nextest
+      # - uses: taiki-e/install-action@nextest
 
       - name: Optional Foundry Install
         if: ${{ inputs.install-foundry == true }}
@@ -134,7 +134,7 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
-          cargo nextest run --workspace ${{ inputs.require-lockfile == true && '--locked' || '' }} ${{ matrix.feature-set }} --cargo-profile ${{ inputs.rust-profile }} --no-tests=warn
+          cargo test run --workspace ${{ inputs.require-lockfile == true && '--locked' || '' }} ${{ matrix.feature-set }} --cargo-profile ${{ inputs.rust-profile }} --no-tests=warn
 
   rustfmt:
     name: Format (${{ inputs.rust-channel }})

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -134,7 +134,7 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
-          cargo test run --workspace ${{ inputs.require-lockfile == true && '--locked' || '' }} ${{ matrix.feature-set }} --cargo-profile ${{ inputs.rust-profile }} --no-tests=warn
+          cargo test run --workspace ${{ inputs.require-lockfile == true && '--locked' || '' }} ${{ matrix.feature-set }}
 
   rustfmt:
     name: Format (${{ inputs.rust-channel }})


### PR DESCRIPTION
This PR replaces nextest with cargo test to resolve CI failures in the latest op-talos PR.

- The CI failures appear to be caused by nextest's process isolation model, where each test runs in a separate process. This breaks the the op-rbuilder integration testing macros. They assume that thread names will contain a specific suffix which is not true under nextest.
- This change *should not* introduce test flakiness or miss any cases that nextest would catch
- Aligns our testing framework with our dependencies (notably op-rbuilder)
- Provides a minor performance improvement by reducing process overhead