### PR TITLE
feat(rust-build-binary): verify SSH key validity before building

### DIFF
--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -105,6 +105,19 @@ jobs:
 
           # Configure Git to use SSH for GitHub URLs
           git config --global url."git@github.com:".insteadOf "https://github.com/"
+      - name: Verify SSH key (fail fast on misconfigured deploy key)
+        if: ${{ inputs.requires-private-deps == true }}
+        run: |
+          # Fail fast if SSH auth to GitHub is broken, before attempting any cargo fetch.
+          # We rely on the SSH exit status; the output is discarded to avoid echoing key fingerprints.
+          ssh -o StrictHostKeyChecking=accept-new -T git@github.com 2>/dev/null
+          status=$?
+          # ssh -T returns 1 on successful auth (GitHub returns "successfully authenticated" but no shell).
+          # Anything else is a real failure.
+          if [ "$status" -ne 1 ]; then
+            echo "::error::SSH authentication to GitHub failed (exit status $status). Check that SSH_PRIVATE_KEY is set and has access to the required repositories."
+            exit 1
+          fi
       - name: Cargo Build Release
         run: |
           # Build command with optional package and manifest path


### PR DESCRIPTION
## Summary

When \`requires-private-deps: true\` is passed, the workflow now runs a preflight \`ssh -T git@github.com\` check before the cargo build step. This fails fast with a clear error if the SSH deploy key is missing or doesn't authenticate.

## Motivation

Previously, a misconfigured deploy key would surface deep inside \`cargo fetch\` with an obscure error. The preflight gives a clear message at the top of the job so maintainers can fix the secret quickly.

## Security

- SSH output is redirected to \`/dev/null\` to avoid echoing key fingerprints
- Exit status is checked explicitly (GitHub's \`ssh -T\` returns 1 on successful auth)

## Test plan

- [ ] CI: existing callers with \`requires-private-deps: false\` (default) skip the check
- [ ] CI: caller with \`requires-private-deps: true\` and a valid key passes
- [ ] CI: caller with \`requires-private-deps: true\` and no/invalid key fails with clear error