### PR TITLE
workflows: add github app as default git auth

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -96,7 +96,7 @@ on:
         type: boolean
         default: false
       requires-private-deps:
-        description: "Requires private dependencies to be fetched, sets up ssh-agent"
+        description: "Requires private dependencies to be fetched (prefers GitHub App token, falls back to SSH key)"
         type: boolean
         default: false
       install-foundry:
@@ -120,8 +120,14 @@ on:
         type: string
         default: ""
     secrets:
+      APP_ID:
+        description: "GitHub App ID for fetching private dependencies (preferred)"
+        required: false
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key for fetching private dependencies (preferred)"
+        required: false
       SSH_PRIVATE_KEY:
-        description: "SSH private key for fetching private dependencies"
+        description: "SSH private key for fetching private dependencies (fallback)"
         required: false
       COMMENT_TOKEN:
         description: "Token for posting PR comments (PAT or GitHub App token)"
@@ -145,8 +151,34 @@ jobs:
       pages-exists: ${{ steps.pages.outputs.exists }}
       pages-path: ${{ steps.pages-path.outputs.path }}
     steps:
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
@@ -157,11 +189,15 @@ jobs:
         with:
           submodules: false
 
-      - name: Configure Git for SSH
+      - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
         run: |
-          git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+          fi
 
       - name: Install submodules
         if: ${{ inputs.submodules == true }}

--- a/.github/workflows/release-docker-ghcr.yaml
+++ b/.github/workflows/release-docker-ghcr.yaml
@@ -15,7 +15,7 @@ on:
         default: 'stable'
         type: string
       requires-private-deps:
-        description: 'Requires private dependencies to be fetched, sets up ssh-agent'
+        description: 'Requires private dependencies to be fetched (prefers GitHub App token, falls back to SSH key)'
         required: false
         default: false
         type: boolean
@@ -40,8 +40,14 @@ on:
         default: ''
         type: string
     secrets:
+      APP_ID:
+        description: 'GitHub App ID for fetching private dependencies (preferred)'
+        required: false
+      APP_PRIVATE_KEY:
+        description: 'GitHub App private key for fetching private dependencies (preferred)'
+        required: false
       SSH_PRIVATE_KEY:
-        description: 'SSH private key for fetching private dependencies'
+        description: 'SSH private key for fetching private dependencies (fallback)'
         required: false
 
 env:
@@ -110,16 +116,39 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup ssh-agent
-        id: ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
-            ${{ secrets.SSH_PRIVATE_KEY }}            
+            ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Build and push
-        if: ${{ inputs.requires-private-deps == false }}
-        id: build-and-push-no-ssh
+        if: ${{ steps.auth.outputs.method != 'ssh' }}
+        id: build-and-push
         uses: docker/build-push-action@v7
         with:
           push: true
@@ -129,12 +158,13 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           tags: ${{ env.REGISTRY_IMAGE }}:${{ github.sha }}
+          secrets: ${{ steps.auth.outputs.method == 'app' && format('git_auth_token={0}', steps.app-token.outputs.token) || '' }}
           build-args: |
             RUST_TOOLCHAIN=${{ inputs.rust-channel }}
             BUILD_FLAGS=${{ inputs.build-flags }} ${{ inputs.require-lockfile == true && '--locked' || '' }}
-      - name: Build and push
-        if: ${{ inputs.requires-private-deps == true }}
-        id: build-and-push-with-ssh
+      - name: Build and push (SSH fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
+        id: build-and-push-ssh
         uses: docker/build-push-action@v7
         with:
           push: true
@@ -148,7 +178,7 @@ jobs:
           build-args: |
             RUST_TOOLCHAIN=${{ inputs.rust-channel }}
             BUILD_FLAGS=${{ inputs.build-flags }} ${{ inputs.require-lockfile == true && '--locked' || '' }}
-        env: 
+        env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
       - name: Move cache
         run: |
@@ -156,14 +186,16 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - name: Export digest
         id: export-digest
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest || steps.build-and-push-ssh.outputs.digest }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          # Get the digest from the appropriate build step
-          if [ "${{ inputs.requires-private-deps }}" = "true" ]; then
-            echo "digest-amd64=${{ matrix.arch == 'amd64' && steps.build-and-push-with-ssh.outputs.digest || '' }}" >> $GITHUB_OUTPUT
-            echo "digest-arm64=${{ matrix.arch == 'arm64' && steps.build-and-push-with-ssh.outputs.digest || '' }}" >> $GITHUB_OUTPUT
+          if [ "$ARCH" = "amd64" ]; then
+            echo "digest-amd64=$DIGEST" >> $GITHUB_OUTPUT
+            echo "digest-arm64=" >> $GITHUB_OUTPUT
           else
-            echo "digest-amd64=${{ matrix.arch == 'amd64' && steps.build-and-push-no-ssh.outputs.digest || '' }}" >> $GITHUB_OUTPUT
-            echo "digest-arm64=${{ matrix.arch == 'arm64' && steps.build-and-push-no-ssh.outputs.digest || '' }}" >> $GITHUB_OUTPUT
+            echo "digest-amd64=" >> $GITHUB_OUTPUT
+            echo "digest-arm64=$DIGEST" >> $GITHUB_OUTPUT
           fi
     outputs:
       digest-amd64: ${{ steps.export-digest.outputs.digest-amd64 }}

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -32,9 +32,15 @@ on:
         type: string
         default: ""
     secrets:
+      APP_ID:
+        description: "GitHub App ID for private git dependencies (unused, accepted for forward compat)"
+        required: false
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key for private git dependencies (unused, accepted for forward compat)"
+        required: false
       SSH_PRIVATE_KEY:
-        description: "SSH private key"
-        required: true
+        description: "SSH private key (unused, accepted for backward compat)"
+        required: false
 
 jobs:
   create-release:
@@ -74,12 +80,6 @@ jobs:
         with:
           name: ${{ inputs.artifact_name }}
           path: artifacts
-
-      - name: Setup ssh-agent
-        uses: webfactory/ssh-agent@v0.10.0
-        with:
-          ssh-private-key: |
-            ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         id: create_release

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -18,7 +18,7 @@ on:
         default: false
         type: boolean
       requires-private-deps:
-        description: 'Requires private dependencies to be fetched, sets up ssh-agent'
+        description: 'Requires private dependencies to be fetched (prefers GitHub App token, falls back to SSH key)'
         required: false
         default: false
         type: boolean
@@ -123,8 +123,14 @@ on:
         default: 'gha'
         type: string
     secrets:
+      APP_ID:
+        description: 'GitHub App ID for fetching private dependencies (preferred)'
+        required: false
+      APP_PRIVATE_KEY:
+        description: 'GitHub App private key for fetching private dependencies (preferred)'
+        required: false
       SSH_PRIVATE_KEY:
-        description: 'SSH private key for fetching private dependencies'
+        description: 'SSH private key for fetching private dependencies (fallback)'
         required: false
 jobs:
   test:
@@ -145,8 +151,32 @@ jobs:
         options: ${{ inputs.dind && '--privileged --shm-size=2g' || '--name noop' }}
         volumes: ${{ inputs.dind && fromJSON('["/var/run/docker.sock:/var/run/docker.sock:ro"]') || fromJSON('[]') }}
     steps:
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
@@ -155,14 +185,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: false  # Important: Don't fetch submodules yet
-      - name: Configure Git for SSH
+      - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
         run: |
-          # Remove the HTTPS conversion that actions/checkout added
-          git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-          
-          # Configure Git to use SSH for GitHub URLs
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+          fi
       - name: Install submodules
         if: ${{ inputs.submodules == true }}
         run: |
@@ -244,14 +275,47 @@ jobs:
       matrix:
         feature-set: ${{ fromJSON(inputs.feature-sets) }}
     steps:
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Configure Git for private deps
+        if: ${{ inputs.requires-private-deps == true }}
+        run: |
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+          fi
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -310,8 +374,32 @@ jobs:
     runs-on: ${{ inputs.runner-group != '' && fromJSON(format('{{"group":"{0}"}}', inputs.runner-group)) || inputs.runner != '' && inputs.runner || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
@@ -320,11 +408,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: false
-      - name: Configure Git for SSH
+      - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
         run: |
-          git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+          fi
       - name: Install submodules
         if: ${{ inputs.submodules == true }}
         run: |
@@ -358,14 +450,47 @@ jobs:
       matrix:
         feature-set: ${{ fromJSON(inputs.feature-sets) }}
     steps:
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6
+      - name: Configure Git for private deps
+        if: ${{ inputs.requires-private-deps == true }}
+        run: |
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
+          fi
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -46,13 +46,19 @@ on:
         default: false
         type: boolean
       requires-private-deps:
-        description: "Requires private dependencies to be fetched, sets up ssh-agent"
+        description: "Requires private dependencies to be fetched (prefers GitHub App token, falls back to SSH key)"
         required: false
         default: false
         type: boolean
     secrets:
+      APP_ID:
+        description: "GitHub App ID for private git dependencies (preferred)"
+        required: false
+      APP_PRIVATE_KEY:
+        description: "GitHub App private key for private git dependencies (preferred)"
+        required: false
       SSH_PRIVATE_KEY:
-        description: "SSH private key for private git dependencies"
+        description: "SSH private key for private git dependencies (fallback)"
         required: false
 permissions:
   contents: read
@@ -91,35 +97,44 @@ jobs:
       - name: Setup sccache
         if: ${{ inputs.enable-sccache == true }}
         uses: mozilla-actions/sccache-action@v0.0.10
-      - name: Setup ssh-agent
+      - name: Detect auth method for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        id: auth
+        shell: bash
+        env:
+          HAS_APP_ID: ${{ secrets.APP_ID }}
+          HAS_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "$HAS_APP_ID" ]; then
+            echo "method=app" >> "$GITHUB_OUTPUT"
+          elif [ -n "$HAS_SSH_KEY" ]; then
+            echo "method=ssh" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::requires-private-deps is true but neither APP_ID nor SSH_PRIVATE_KEY is set"
+            exit 1
+          fi
+      - name: Generate GitHub App token
+        if: ${{ steps.auth.outputs.method == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Setup ssh-agent (fallback)
+        if: ${{ steps.auth.outputs.method == 'ssh' }}
         uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: |
             ${{ secrets.SSH_PRIVATE_KEY }}
-      - name: Configure Git for SSH
+      - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
         run: |
-          # Remove the HTTPS conversion that actions/checkout added
-          git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-
-          # Configure Git to use SSH for GitHub URLs
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
-      - name: Verify SSH key (fail fast on misconfigured deploy key)
-        if: ${{ inputs.requires-private-deps == true }}
-        run: |
-          # Fail fast if SSH auth to GitHub is broken, before attempting any cargo fetch.
-          # Note: ssh -T to git@github.com ALWAYS exits non-zero (GitHub closes the shell
-          # session), so we can't let `set -e` short-circuit. We allow the command to "fail"
-          # via `|| status=$?` so we can inspect the exit code explicitly.
-          # Output is discarded to avoid echoing key fingerprints.
-          status=0
-          ssh -o StrictHostKeyChecking=accept-new -T git@github.com 2>/dev/null || status=$?
-          # Exit status 1 means successful auth (GitHub's expected response for `ssh -T`).
-          # Exit status 255 typically means auth failure (no valid key, wrong key, etc.).
-          if [ "$status" -ne 1 ]; then
-            echo "::error::SSH authentication to GitHub failed (exit status $status). Check that SSH_PRIVATE_KEY is set and valid."
-            exit 1
+          if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
+            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          else
+            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
+            git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Cargo Build Release
         run: |


### PR DESCRIPTION
# Description

This PR adds an integration with our Github CI app to pull private dependencies. The previous behavior requested a SSH_PRIVATE_KEY that has rights to pull the private repo content over `git@github.com`. This PR changes that in a way that requests our [Github App](https://github.com/organizations/phylaxsystems/settings/apps/phylax-ci-private-deps) to issue a short-lived HTTPS token and changes to HTTPS as the transport. In that way, no key can get compromised.

**NOTE**: the previous behavior is still untouched if the `APP_ID` isn't supplied