### PR TITLE
fix: pass app token via env instead of shell interpolation

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -191,9 +191,11 @@ jobs:
 
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -187,9 +187,11 @@ jobs:
           submodules: false  # Important: Don't fetch submodules yet
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
@@ -309,9 +311,11 @@ jobs:
         uses: actions/checkout@v6
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
@@ -410,9 +414,11 @@ jobs:
           submodules: false
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
@@ -484,9 +490,11 @@ jobs:
         uses: actions/checkout@v6
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -129,9 +129,11 @@ jobs:
             ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Configure Git for private deps
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
             git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"


### PR DESCRIPTION
## Summary

- Binds the GitHub App token through `env: GH_APP_TOKEN` instead of direct `${{ }}` interpolation in shell scripts
- Prevents the token from appearing in the rendered command line (`/proc/<pid>/cmdline`) and debug logs
- Addresses review feedback from #88

## Changes

All "Configure Git for private deps" steps across `rust-base.yaml`, `rust-build-binary.yaml`, and `benchmark.yaml` now use `${GH_APP_TOKEN}` (shell env var) instead of `${{ steps.app-token.outputs.token }}` (GHA interpolation).

The Docker workflow (`release-docker-ghcr.yaml`) is unchanged — it passes the token as a YAML input to `docker/build-push-action`, not through a shell command, so it's already safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)