### PR TITLE
fix(docker-ghcr): pass -y to ca-certificates/curl install

### DIFF
--- a/.github/workflows/release-docker-ghcr.yaml
+++ b/.github/workflows/release-docker-ghcr.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Install Docker CE
         run: |
           sudo apt update
-          sudo apt install ca-certificates curl
+          sudo apt install -y ca-certificates curl
           sudo install -m 0755 -d /etc/apt/keyrings
           sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
           sudo chmod a+r /etc/apt/keyrings/docker.asc


### PR DESCRIPTION
## Problem

All `Docker GHCR Push` jobs in `credible-sdk` (and any consumer of this reusable workflow) are failing at the **Install Docker CE** step:

```
3 upgraded, 0 newly installed, 0 to remove and 49 not upgraded.
Need to get 615 kB of archives.
Do you want to continue? [Y/n] Abort.
##[error]Process completed with exit code 1.
```

Failing run: https://github.com/phylaxsystems/credible-sdk/actions/runs/27964792275

## Root cause

The step ran:

```sh
sudo apt install ca-certificates curl
```

without `-y`. While `ca-certificates`/`curl` were already current on the runner image this was a silent no-op, so it passed. Jammy has since published updates for `ca-certificates`, `curl`, and `libcurl4`, so the command now wants to upgrade 3 packages — that triggers the interactive `Do you want to continue? [Y/n]` prompt. CI stdin is non-interactive, apt reads EOF → `Abort.` → exit 1, before Docker is ever installed.

Nothing changed in the consumer repos; the upstream package index did. (The recent `actions/checkout@v6→v7` bump is unrelated — that step is green in the logs.)

## Fix

Add `-y` so the `ca-certificates`/`curl` install is non-interactive, matching the `docker-ce` install a few lines below it.