### PR TITLE
rust: isolate private-deps git config to stop stale-token accumulation

### DIFF
--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -192,12 +192,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Install submodules
         if: ${{ inputs.submodules == true }}
         run: |
@@ -319,12 +329,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -387,12 +407,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
       - name: Install cargo-shear
@@ -450,12 +480,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Run cargo-deny (preinstalled)
         if: ${{ inputs.deny-preinstalled == true }}
         env:
@@ -516,12 +556,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Install submodules
         if: ${{ inputs.submodules == true }}
         run: |
@@ -595,12 +645,22 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write to an isolated per-run git config instead of the shared global
+          # one. On self-hosted runners $HOME persists across jobs and the token
+          # is baked into the section name, so `git config --global` appends a
+          # new url.<token>.insteadOf entry every run and never removes stale
+          # ones; Git then rewrites github.com through an expired/wrongly-scoped
+          # token and private-dep fetches fail with "Invalid username or token".
+          # GIT_CONFIG_GLOBAL points Git at a file we recreate each run, so
+          # nothing accumulates.
+          git_config="${RUNNER_TEMP}/private-deps-gitconfig"
+          rm -f "$git_config"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
-            git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+            git config --file "$git_config" url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
-            git config --global url."git@github.com:".insteadOf "https://github.com/"
+            git config --file "$git_config" url."git@github.com:".insteadOf "https://github.com/"
           fi
+          echo "GIT_CONFIG_GLOBAL=$git_config" >> "$GITHUB_ENV"
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
# Summary

The "Configure Git for private deps" steps wrote the App-token URL rewrite with `git config --global`. Because the token is part of the section name (`url.https://x-access-token:<TOKEN>@github.com/`), every run created a new section, and on self-hosted runners `$HOME` persists across jobs so the rewrites accumulated indefinitely (observed 200+ entries in a runner's ~/.gitconfig). Git resolves github.com through one of the stale, equal-length matches — a token minted before the repo grant / already expired — so private Cargo git deps fail with "Invalid username or token" even after the GitHub App is granted access to the repo. Public deps still fetch, which masks the cause.

Write the rewrite to a fresh `${RUNNER_TEMP}/private-deps-gitconfig` file (recreated each run) and point Git at it via GIT_CONFIG_GLOBAL. Nothing accumulates in the shared ~/.gitconfig, and existing accumulated entries are no longer consulted. Matches the approach already used by the setup-private-deps composite action.