### PR TITLE
fix(ci): isolate private-deps git rewrite in job-scoped config

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -223,6 +223,15 @@ jobs:
         with:
           key: ${{ inputs.rust-channel }}-bench
 
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Optional Foundry Install
         if: ${{ inputs.install-foundry == true }}
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -196,10 +196,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -228,6 +228,7 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        working-directory: ${{ inputs.working-directory }}
         run: cargo fetch
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -228,6 +228,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         working-directory: ${{ inputs.working-directory }}
         run: cargo fetch
       - name: Clear private-deps git rewrite

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -192,10 +192,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Install submodules
@@ -319,10 +324,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Install Rust toolchain
@@ -387,10 +397,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Install cargo-binstall
@@ -450,10 +465,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Run cargo-deny (preinstalled)
@@ -516,10 +536,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Install submodules
@@ -595,10 +620,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Install Rust toolchain

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -208,6 +208,19 @@ jobs:
         run: |
           git submodule sync --recursive
           git submodule update --init --recursive
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust-channel }}
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
         if: ${{ inputs.install-dapp-dependencies }}
@@ -218,10 +231,6 @@ jobs:
         if: ${{ inputs.install-dapp-dependencies }}
         run: |
           pnpm install -g next
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.rust-channel }}
       - name: Setup sccache
         if: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' }}
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -340,6 +349,15 @@ jobs:
         with:
           toolchain: ${{ inputs.rust-channel }}
           components: clippy
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Setup sccache
         if: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' }}
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -408,6 +426,15 @@ jobs:
           else
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
       - name: Install cargo-shear
@@ -476,6 +503,15 @@ jobs:
           else
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Run cargo-deny (preinstalled)
         if: ${{ inputs.deny-preinstalled == true }}
         env:
@@ -556,6 +592,15 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-channel }}
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Install cargo-binstall
         if: ${{ inputs.zepter-preinstalled != true }}
         uses: cargo-bins/cargo-binstall@732870f031d2fb36309d0deaf36abcc704a7be65 # v1.20.1
@@ -635,6 +680,15 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ inputs.rust-channel }}
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Setup sccache
         if: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' }}
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -217,6 +217,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
@@ -354,6 +356,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
@@ -431,6 +435,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
@@ -508,6 +514,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
@@ -597,6 +605,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
@@ -685,6 +695,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: cargo fetch ${{ inputs.require-lockfile == true && '--locked' || '' }}
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -151,6 +151,8 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
           FETCH_CMD="cargo fetch"
 

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -146,6 +146,15 @@ jobs:
           else
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
+      # Pre-fetch every crate while the token rewrite is in place, then drop
+      # the token before any build script, proc macro, or test can run (the
+      # remaining cargo/forge steps resolve from the populated cache).
+      - name: Fetch Rust dependencies
+        if: ${{ inputs.requires-private-deps == true }}
+        run: cargo fetch
+      - name: Clear private-deps git rewrite
+        if: ${{ always() && inputs.requires-private-deps == true }}
+        run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"
       - name: Cargo Build Release
         run: |
           if [ "${{ inputs.requires-private-deps }}" = "true" ]; then

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -135,10 +135,15 @@ jobs:
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Write the rewrite to a job-scoped config file instead of the shared
+          # ~/.gitconfig: runner processes on one host share HOME, so the global
+          # file races concurrent jobs and accumulates revoked tokens that
+          # shadow fresh ones (git insteadOf is first-match-wins). See ENG-3746.
+          export GIT_CONFIG_GLOBAL="${RUNNER_TEMP}/private-deps-gitconfig"
+          echo "GIT_CONFIG_GLOBAL=${GIT_CONFIG_GLOBAL}" >> "$GITHUB_ENV"
           if [ "${{ steps.auth.outputs.method }}" = "app" ]; then
             git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
           else
-            git config --global --unset-all url.https://github.com/.insteadOf || echo "No HTTPS config to unset"
             git config --global url."git@github.com:".insteadOf "https://github.com/"
           fi
       - name: Cargo Build Release

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -151,7 +151,16 @@ jobs:
       # remaining cargo/forge steps resolve from the populated cache).
       - name: Fetch Rust dependencies
         if: ${{ inputs.requires-private-deps == true }}
-        run: cargo fetch
+        run: |
+          FETCH_CMD="cargo fetch"
+
+          # Mirror the build's manifest path so a workspace outside the repo
+          # root has its private deps fetched before the token is cleared
+          if [ -n "${{ inputs.manifest-path }}" ]; then
+            FETCH_CMD="$FETCH_CMD --manifest-path ${{ inputs.manifest-path }}"
+          fi
+
+          $FETCH_CMD
       - name: Clear private-deps git rewrite
         if: ${{ always() && inputs.requires-private-deps == true }}
         run: rm -f "${RUNNER_TEMP}/private-deps-gitconfig"

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -154,7 +154,7 @@ jobs:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
         run: |
-          FETCH_CMD="cargo fetch"
+          FETCH_CMD="cargo fetch --locked"
 
           # Mirror the build's manifest path so a workspace outside the repo
           # root has its private deps fetched before the token is cleared


### PR DESCRIPTION
## Problem

Private-dep fetches on the self-hosted pool fail with `Invalid username or token` even though the GitHub App token is freshly minted and the app has repo access (phylaxsystems/credible-sdk ENG-3746).

Root cause: all 8 runner processes on the pool host share one HOME, hence one `~/.gitconfig`. Every `Configure Git for private deps` step appends a `url."https://x-access-token:<token>@github.com/".insteadOf` entry and nothing removes it (the token itself is revoked at job end by `create-github-app-token`'s post step). Git resolves duplicate `insteadOf` rewrites **first-match-wins**, so once one stale entry exists, every subsequent job fetches with the oldest *revoked* token. The pool host had accumulated **271 stale entries**; diagnostic run: [credible-sdk run 28852748799](https://github.com/phylaxsystems/credible-sdk/actions/runs/28852748799) (phase A reproduces the shadowing with a fresh valid token, phase B purges and verifies a live fetch).

This stayed invisible on `main` builds because the persistent cargo git cache satisfied fetches offline; any uncached rev exposed it.

## Fix

Write the rewrite to a job-scoped config file (`GIT_CONFIG_GLOBAL=$RUNNER_TEMP/private-deps-gitconfig`) instead of the shared `~/.gitconfig`, in all 8 `Configure Git for private deps` steps (rust-base ×6, benchmark, rust-build-binary):

- no cross-job races on the shared file (two concurrent jobs previously used *each other's* tokens, which die when the other job ends)
- nothing accumulates; `RUNNER_TEMP` is wiped per job
- the existing poisoned `~/.gitconfig` becomes invisible to these jobs
- the ssh-mode legacy `--unset-all` line is dropped — the file starts empty

The stale entries on the credible-sdk pool host were already purged by the diagnostic run above; after this merges, nothing recreates them. Companion PR applies the same fix to credible-sdk's local workflow.

Refs: ENG-3746, ENG-3725, ENG-3729

🤖 Generated with [Claude Code](https://claude.com/claude-code)