### PR TITLE
rust-base: fix sccache backend handling

### DIFF
--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -118,7 +118,7 @@ on:
         default: false
         type: boolean
       sccache-backend:
-        description: 'sccache backend: "gha" uses GitHub Actions cache, "local" relies on runner .env (for self-hosted runners with local disk cache)'
+        description: 'sccache backend: "gha" uses GitHub Actions cache, "local" uses the runner-provided SCCACHE_DIR on local disk (for self-hosted runners)'
         required: false
         default: 'gha'
         type: string
@@ -139,8 +139,8 @@ jobs:
     timeout-minutes: 15
     env:
       SCCACHE_GHA_ENABLED: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'true' || 'false' }}
-      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'sccache' || '' }}
-      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && '0' || '' }}
+      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && 'sccache' || '' }}
+      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && '0' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -288,8 +288,8 @@ jobs:
     timeout-minutes: 15
     env:
       SCCACHE_GHA_ENABLED: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'true' || 'false' }}
-      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'sccache' || '' }}
-      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && '0' || '' }}
+      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && 'sccache' || '' }}
+      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && '0' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -628,8 +628,8 @@ jobs:
     timeout-minutes: 15
     env:
       SCCACHE_GHA_ENABLED: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'true' || 'false' }}
-      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'sccache' || '' }}
-      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && '0' || '' }}
+      RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && 'sccache' || '' }}
+      CARGO_INCREMENTAL: ${{ inputs.enable-sccache == true && '0' || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -136,7 +136,7 @@ jobs:
   test:
     name: Test (${{ inputs.rust-channel }})
     runs-on: ${{ inputs.runner-group != '' && fromJSON(format('{{"group":"{0}"}}', inputs.runner-group)) || inputs.runner != '' && inputs.runner || 'ubuntu-latest' }}
-    timeout-minutes: 15
+    timeout-minutes: 60
     env:
       SCCACHE_GHA_ENABLED: ${{ inputs.enable-sccache == true && inputs.sccache-backend == 'gha' && 'true' || 'false' }}
       RUSTC_WRAPPER: ${{ inputs.enable-sccache == true && 'sccache' || '' }}


### PR DESCRIPTION
## Description

- properly selects `sccache` as the backend when enabled