### PR TITLE
[codex] upgrade GitHub App token action

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -172,7 +172,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -174,7 +174,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -174,7 +174,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/release-docker-ghcr.yaml
+++ b/.github/workflows/release-docker-ghcr.yaml
@@ -138,7 +138,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/release-docker-ghcr.yaml
+++ b/.github/workflows/release-docker-ghcr.yaml
@@ -140,7 +140,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)

--- a/.github/workflows/release-docker-ghcr.yaml
+++ b/.github/workflows/release-docker-ghcr.yaml
@@ -140,7 +140,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -171,7 +171,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -319,7 +319,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -403,7 +403,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -482,7 +482,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -563,7 +563,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -659,7 +659,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -173,7 +173,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -321,7 +321,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -405,7 +405,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -484,7 +484,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -565,7 +565,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -661,7 +661,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)

--- a/.github/workflows/rust-base.yaml
+++ b/.github/workflows/rust-base.yaml
@@ -173,7 +173,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -321,7 +321,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -405,7 +405,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -484,7 +484,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -565,7 +565,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)
@@ -661,7 +661,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: Generate GitHub App token
         if: ${{ steps.auth.outputs.method == 'app' }}
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -121,7 +121,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: Iv23liwewGcSZnHOmKxv
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)

--- a/.github/workflows/rust-build-binary.yaml
+++ b/.github/workflows/rust-build-binary.yaml
@@ -121,7 +121,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: Iv23liwewGcSZnHOmKxv
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Setup ssh-agent (fallback)


### PR DESCRIPTION
## What

- upgrade every `actions/create-github-app-token` call from v2 to v3
- preserve the existing App ID/private-key interface for current callers

## Why

GitHub-hosted and ARC jobs now force v2's deprecated Node 20 runtime onto Node
24 and emit warnings for every private-dependency matrix job. v3 uses the
current runtime while remaining compatible with the existing credentials.

The separate `app-id` to `client-id` migration is intentionally deferred
until the GitHub App key rotation because those identifiers are not
interchangeable.

## Validation

- targeted `actionlint` across all changed workflows
- `git diff --check`
- PCL and credible-sdk callers updated and validating on their existing PRs

Pre-existing actionlint findings in dynamic container-volume expressions and
unrelated shell snippets were ignored explicitly; this patch changes only
action version references.
