### PR TITLE
feat(npm)!: publish with trusted publishing

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -18,10 +18,10 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      NPM_TOKEN:
-        description: "NPM authentication token"
-        required: true
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -59,7 +59,5 @@ jobs:
           name: ${{ inputs.artifact_name }}
           path: ${{ inputs.artifacts_path }}
 
-      - name: Publish to NPM
+      - name: Publish to npm
         run: npm publish --access public --ignore-scripts=${{ inputs.ignore_scripts }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ A repository of useful actions we use across the repositories at Phylax Systems.
 
 Original inspiration (and probably quite a few of workflows) originate from [init4/actions](https://github.com/init4tech/actions). They are re-used under their Apache 2.0 License.
 
+## npm trusted publishing
+
+`release-npm.yaml` publishes through npm's OpenID Connect integration without an
+`NPM_TOKEN`. The caller must grant `id-token: write` and `contents: read`; configure
+the calling workflow's filename as the trusted publisher on npm, even when the
+publish command runs in the reusable workflow.
+
+```yaml
+jobs:
+  release-npm:
+    permissions:
+      contents: read
+      id-token: write
+    uses: phylaxsystems/actions/.github/workflows/release-npm.yaml@main
+```
+
 ## Rust base feature matrices
 
 Control which feature combinations run for test, clippy, and docs using matrix inputs `testfeature-sets`. Each takes a JSON string array where each element (e.g., "" for default, "--all-features", "--no-default-features --features=foo") triggers a separate job run with those flags passed to cargo. The default is [""].


### PR DESCRIPTION
Switches reusable npm releases to GitHub OIDC and removes long-lived token authentication. Callers must grant `id-token: write` and configure the calling workflow as an npm trusted publisher; existing token-based callers need migration before their next release. Companion migration: https://github.com/phylaxsystems/credible-layer-contracts/pull/34.