### PR TITLE
fix(npm): publish from caller workflow

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -34,6 +34,12 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      # npm >= 11.5.1 is required for OIDC trusted publishing. Installing the
+      # current CLI keeps that requirement independent of the runner image.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Verify tag matches package.json version
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Repository tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Test release workflows
+        run: python3 -m unittest discover -s test -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -6,19 +6,30 @@ Original inspiration (and probably quite a few of workflows) originate from [ini
 
 ## npm trusted publishing
 
-`release-npm.yaml` publishes through npm's OpenID Connect integration without an
-`NPM_TOKEN`. The caller must grant `id-token: write` and `contents: read`; configure
-the calling workflow's filename as the trusted publisher on npm, even when the
-publish command runs in the reusable workflow.
+The `release-npm` action publishes through npm's OpenID Connect integration without
+an `NPM_TOKEN`. Run it as a step in the repository's release workflow so npm can
+match the trusted publisher directly to that workflow file. The job must grant
+`id-token: write` and `contents: read`.
 
 ```yaml
 jobs:
   release-npm:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    uses: phylaxsystems/actions/.github/workflows/release-npm.yaml@main
+    steps:
+      - uses: phylaxsystems/actions/release-npm@main
 ```
+
+Configure the caller's workflow filename as the trusted publisher on npm. The
+legacy reusable `release-npm.yaml` workflow remains available for existing callers,
+but the step action avoids reusable-workflow identity mismatches during npm's OIDC
+token exchange.
+
+For a non-destructive retry of an existing tag, dispatch the caller workflow and
+pass that tag through the action's `release_tag` input. The action checks out the
+tag and verifies it still matches `package.json` before publishing.
 
 ## Rust base feature matrices
 

--- a/release-npm/action.yml
+++ b/release-npm/action.yml
@@ -1,0 +1,71 @@
+name: Publish npm package
+description: Publish an npm package through GitHub OIDC trusted publishing
+
+inputs:
+  artifact_name:
+    description: Name of the artifact to download
+    required: false
+    default: ""
+  artifacts_path:
+    description: Path where the downloaded artifact should be placed
+    required: false
+    default: ""
+  ignore_scripts:
+    description: Whether npm should ignore lifecycle scripts during publish
+    required: false
+    default: "false"
+  release_tag:
+    description: Existing tag to check out and publish during a manual retry
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.release_tag }}
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "24"
+        registry-url: "https://registry.npmjs.org"
+        package-manager-cache: false
+
+    # npm >= 11.5.1 is required for OIDC trusted publishing. Installing the
+    # current CLI keeps that requirement independent of the runner image.
+    - name: Update npm
+      shell: bash
+      run: npm install -g npm@latest
+
+    - name: Verify tag matches package.json version
+      shell: bash
+      env:
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        tag_version="$RELEASE_TAG"
+        if [ -z "$tag_version" ]; then
+          tag_version=${GITHUB_REF#refs/tags/}
+        fi
+        package_version=$(node -p "require('./package.json').version")
+
+        echo "Tag version: $tag_version"
+        echo "Package.json version: $package_version"
+
+        if [ "$tag_version" != "$package_version" ]; then
+          echo "Error: Tag version ($tag_version) does not match package.json version ($package_version)"
+          exit 1
+        fi
+
+    - name: Download artifacts
+      if: ${{ inputs.artifact_name != '' }}
+      uses: actions/download-artifact@v8
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ inputs.artifacts_path }}
+
+    - name: Publish to npm
+      shell: bash
+      run: npm publish --access public --ignore-scripts=${{ inputs.ignore_scripts }}

--- a/test/test_release_npm.py
+++ b/test/test_release_npm.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ReleaseNpmWorkflowTest(unittest.TestCase):
+    def test_step_action_publishes_from_the_calling_workflow(self):
+        action_path = ROOT / "release-npm" / "action.yml"
+
+        self.assertTrue(
+            action_path.exists(),
+            "trusted publishing must run as a step in the caller's workflow",
+        )
+
+        action = action_path.read_text()
+        self.assertIn("using: composite", action)
+        self.assertIn("release_tag:", action)
+        self.assertIn("ref: ${{ inputs.release_tag }}", action)
+        self.assertIn("RELEASE_TAG: ${{ inputs.release_tag }}", action)
+        self.assertIn("package-manager-cache: false", action)
+        self.assertIn("npm install -g npm@latest", action)
+        self.assertIn("npm publish", action)
+        self.assertNotIn("NPM_TOKEN", action)
+        self.assertNotIn("NODE_AUTH_TOKEN", action)
+
+    def test_reusable_workflow_uses_an_oidc_capable_npm(self):
+        workflow = (ROOT / ".github" / "workflows" / "release-npm.yaml").read_text()
+
+        self.assertIn("id-token: write", workflow)
+        self.assertIn("package-manager-cache: false", workflow)
+        self.assertIn("npm install -g npm@latest", workflow)
+        self.assertNotIn("NPM_TOKEN", workflow)
+        self.assertNotIn("NODE_AUTH_TOKEN", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes trusted publishing by running npm publish under the caller workflow identity and guaranteeing an OIDC-capable npm CLI. It retains the reusable workflow for compatibility and addresses the failed credible-layer-contracts release: https://github.com/phylaxsystems/credible-layer-contracts/actions/runs/30081908981/job/89445253183.