### PR TITLE
refactor(npm): rely on tag-triggered releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,6 @@ legacy reusable `release-npm.yaml` workflow remains available for existing calle
 but the step action avoids reusable-workflow identity mismatches during npm's OIDC
 token exchange.
 
-For a non-destructive retry of an existing tag, dispatch the caller workflow and
-pass that tag through the action's `release_tag` input. The action checks out the
-tag and verifies it still matches `package.json` before publishing.
-
 ## Rust base feature matrices
 
 Control which feature combinations run for test, clippy, and docs using matrix inputs `testfeature-sets`. Each takes a JSON string array where each element (e.g., "" for default, "--all-features", "--no-default-features --features=foo") triggers a separate job run with those flags passed to cargo. The default is [""].

--- a/release-npm/action.yml
+++ b/release-npm/action.yml
@@ -14,18 +14,12 @@ inputs:
     description: Whether npm should ignore lifecycle scripts during publish
     required: false
     default: "false"
-  release_tag:
-    description: Existing tag to check out and publish during a manual retry
-    required: false
-    default: ""
 
 runs:
   using: composite
   steps:
     - name: Checkout repository
       uses: actions/checkout@v7
-      with:
-        ref: ${{ inputs.release_tag }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -42,13 +36,8 @@ runs:
 
     - name: Verify tag matches package.json version
       shell: bash
-      env:
-        RELEASE_TAG: ${{ inputs.release_tag }}
       run: |
-        tag_version="$RELEASE_TAG"
-        if [ -z "$tag_version" ]; then
-          tag_version=${GITHUB_REF#refs/tags/}
-        fi
+        tag_version=${GITHUB_REF#refs/tags/}
         package_version=$(node -p "require('./package.json').version")
 
         echo "Tag version: $tag_version"

--- a/test/test_release_npm.py
+++ b/test/test_release_npm.py
@@ -16,9 +16,6 @@ class ReleaseNpmWorkflowTest(unittest.TestCase):
 
         action = action_path.read_text()
         self.assertIn("using: composite", action)
-        self.assertIn("release_tag:", action)
-        self.assertIn("ref: ${{ inputs.release_tag }}", action)
-        self.assertIn("RELEASE_TAG: ${{ inputs.release_tag }}", action)
         self.assertIn("package-manager-cache: false", action)
         self.assertIn("npm install -g npm@latest", action)
         self.assertIn("npm publish", action)


### PR DESCRIPTION
Removes the unused manual-retry input now that failed releases are retriggered through their version tag. This keeps the caller-identity OIDC publisher focused on the tag-triggered release path.